### PR TITLE
Fix stale clinician patient picker (force-dynamic on /api/patients)

### DIFF
--- a/app/api/patients/route.ts
+++ b/app/api/patients/route.ts
@@ -2,6 +2,12 @@ import { NextResponse } from "next/server";
 import prisma from "@/lib/db/prisma";
 import { PatientInfo } from "@/lib/types";
 
+// Patient list must reflect live DB state. Without this, Next.js 14 App Router
+// statically optimizes this GET (no dynamic params, cookies, headers, etc.)
+// and caches the response at build time — which serves stale data after any
+// patient is added/removed/renamed at runtime.
+export const dynamic = "force-dynamic";
+
 export async function GET() {
   try {
     const patients = await prisma.patient.findMany({


### PR DESCRIPTION
## Summary

- `/api/patients` was statically optimized by Next.js 14 App Router (no dynamic features used), so the patient list returned to the clinician dashboard was a build-time snapshot.
- After patients were added/renamed/deleted at runtime, the picker kept showing the stale snapshot. Clicking a stale entry sent its now-invalid ID to `/api/patients/[id]/exercise-progress`, returning 404 and surfacing as "Failed to fetch progress data" in the UI.
- Adds `export const dynamic = "force-dynamic"` so the route is always rendered per-request against the live DB.

## Verification

- Before: `curl https://dxtr-psi.vercel.app/api/patients` returned 4 patients including deleted IDs (`edwin-001`, `agatha-001`, `giles-001`).
- DB truth (via Supabase REST): only `demo-live-001` and `gordon-001` exist.
- After deploy, expected: `/api/patients` returns the 2 actual patients, clinician picker no longer 404s when Gordon is selected.

## Test plan

- [ ] After Vercel auto-deploys, `curl https://dxtr-psi.vercel.app/api/patients` returns exactly the 2 patients in the DB
- [ ] `/clinician` → pick Gordon → dashboard renders his 30-day data (no "Failed to fetch progress data")

🤖 Generated with [Claude Code](https://claude.com/claude-code)