### PR TITLE
Label chart axes on the per-game dashboard panels

### DIFF
--- a/components/progress/ExpandedGamePanel.tsx
+++ b/components/progress/ExpandedGamePanel.tsx
@@ -95,18 +95,20 @@ export function ExpandedGamePanel({ game, aggregate, dailyBuckets, patientId, cl
 
               <TabsContent value="reps">
                 <ChartContainer config={repsChartConfig} className="h-[250px] w-full">
-                  <BarChart data={repsData} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
+                  <BarChart data={repsData} margin={{ top: 8, right: 8, bottom: 16, left: 18 }}>
                     <CartesianGrid strokeDasharray="3 3" stroke="#E5E7EB" vertical={false} />
                     <XAxis
                       dataKey="label"
                       tick={{ fontSize: 10, fill: "#9CA3AF" }}
                       axisLine={false}
                       tickLine={false}
+                      label={{ value: "Date", position: "insideBottom", offset: -4, style: { fill: "#9CA3AF", fontSize: 10 } }}
                     />
                     <YAxis
                       tick={{ fontSize: 10, fill: "#9CA3AF" }}
                       axisLine={false}
                       tickLine={false}
+                      label={{ value: "Reps", angle: -90, position: "insideLeft", offset: 8, style: { fill: "#9CA3AF", fontSize: 10 } }}
                     />
                     <ReferenceLine
                       y={game.targetRepsPerDay}
@@ -122,18 +124,26 @@ export function ExpandedGamePanel({ game, aggregate, dailyBuckets, patientId, cl
 
               <TabsContent value="outcome">
                 <ChartContainer config={outcomeChartConfig} className="h-[250px] w-full">
-                  <LineChart data={outcomeData} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
+                  <LineChart data={outcomeData} margin={{ top: 8, right: 8, bottom: 16, left: 18 }}>
                     <CartesianGrid strokeDasharray="3 3" stroke="#E5E7EB" vertical={false} />
                     <XAxis
                       dataKey="label"
                       tick={{ fontSize: 10, fill: "#9CA3AF" }}
                       axisLine={false}
                       tickLine={false}
+                      label={{ value: "Date", position: "insideBottom", offset: -4, style: { fill: "#9CA3AF", fontSize: 10 } }}
                     />
                     <YAxis
                       tick={{ fontSize: 10, fill: "#9CA3AF" }}
                       axisLine={false}
                       tickLine={false}
+                      label={{
+                        value: `${game.primaryMetricLabel}${game.primaryMetricUnit ? ` (${game.primaryMetricUnit})` : ""}`,
+                        angle: -90,
+                        position: "insideLeft",
+                        offset: 8,
+                        style: { fill: "#9CA3AF", fontSize: 10, textAnchor: "middle" },
+                      }}
                     />
                     <ChartTooltip content={<ChartTooltipContent />} />
                     <Line
@@ -205,19 +215,21 @@ function DifficultyTab({
 
   return (
     <ChartContainer config={config} className="h-[250px] w-full">
-      <LineChart data={data} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
+      <LineChart data={data} margin={{ top: 8, right: 8, bottom: 16, left: 18 }}>
         <CartesianGrid strokeDasharray="3 3" stroke="#E5E7EB" vertical={false} />
         <XAxis
           dataKey="label"
           tick={{ fontSize: 10, fill: "#9CA3AF" }}
           axisLine={false}
           tickLine={false}
+          label={{ value: "Date", position: "insideBottom", offset: -4, style: { fill: "#9CA3AF", fontSize: 10 } }}
         />
         <YAxis
           tick={{ fontSize: 10, fill: "#9CA3AF" }}
           axisLine={false}
           tickLine={false}
           domain={[0, 100]}
+          label={{ value: "Success Rate (%)", angle: -90, position: "insideLeft", offset: 8, style: { fill: "#9CA3AF", fontSize: 10, textAnchor: "middle" } }}
         />
         <ChartTooltip content={<ChartTooltipContent />} />
         <Line


### PR DESCRIPTION
## Summary

The expanded game panel shows three charts (Reps Trend, Outcome Trend, Difficulty) but the axes only had tick marks — no titles. Adds clear X-axis ("Date") and Y-axis labels to all three, so it's unambiguous what every line/bar represents.

- **Reps Trend** → Y: "Reps"
- **Difficulty** → Y: "Success Rate (%)"
- **Outcome Trend** → Y derived from each game's existing `primaryMetricLabel` + `primaryMetricUnit`:
  - car-racer → "Avg Dodge Angle (°)"
  - alien-abduction → "Avg Level Reached"
  - rhythm-rehab → "Avg Reaction Time (ms)"
  - fly-swatter → "Shoo Accuracy (%)"
  - storm-witch → "Avg Grip Force (%)"
  - fossil-dusting → "Avg Range of Motion (°)"

Matches the existing in-axis label pattern from `RepsTimelineStrip` (rotated -90°, gray, 10px). Bumps chart margins (bottom 0→16, left 0→18) so the rotated text doesn't clip ticks. 15 lines changed, isolated to `components/progress/ExpandedGamePanel.tsx`.

## Known follow-ups (out of scope for this PR)

- Fly Swatter / Storm Witch / Fossil Dusting's Outcome Trend lines still plot flat-zero because `extractPrimaryMetric` in `lib/exercise/aggregator.ts` has no case for `"accuracy"`, `"avgForce"`, `"avgROM"`. The Y label now correctly says what the chart is *intended* to show, but the line is still zero until the aggregator is extended.
- Alien Abduction's "Avg Level Reached" is actually the mean of `achievedAngle` (raw FSR ADC, 600–2800). Either the label should be renamed or the metric should be a real level.

## Test plan

- [ ] After deploy, `/clinician?patientId=gordon-001` → click each of the 6 game cards
- [ ] For each game, all three tabs (Reps / Outcome / Difficulty) show:
  - "Date" centred below the X-axis
  - Vertical Y-axis title flush against the axis ticks (no clipping, no overlap)
- [ ] Outcome Trend Y-title differs per game (matches the table above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)