### PR TITLE
Fly Swatter: fix double-hit on held flick + 20% less sensitive

### DIFF
--- a/public/fly_swatter/index.html
+++ b/public/fly_swatter/index.html
@@ -701,10 +701,19 @@ let esp32Port = null;
 let esp32Reader = null;
 let esp32Buffer = '';
 
-const SHOO_TRIGGER_CM = 2;
-const SHOO_COOLDOWN_MS = 600;
+// 20% less sensitive than the previous 2 cm — finger must come closer to register.
+const SHOO_TRIGGER_CM  = 1.6;
+// Must rise back above this before another swat can register (hysteresis).
+// Prevents one held flick from killing the next-spawned fly when its cooldown
+// happens to expire while the user's hand is still in the sensor's range.
+const SHOO_RELEASE_CM  = 5;
+// Longer than the fly-death → respawn cycle (~1 s) so a held finger can't
+// re-fire on the new fly purely on timing.
+const SHOO_COOLDOWN_MS = 1200;
 let lastDistanceCm = 999;
 let lastShooTime = 0;
+// false from the moment of a trigger until the sensor reading clears RELEASE_CM.
+let shooArmed = true;
 
 /** TEMP serial monitor — remove when done debugging */
 const SERIAL_MONITOR_MAX_LINES = 100;
@@ -839,7 +848,13 @@ function parseESP32Data(jsonStr) {
 
     appendSerialMonitorLine(`dist=${dist.toFixed(2)} prev=${prev.toFixed(2)}`);
 
-    if (dist < SHOO_TRIGGER_CM && now - lastShooTime > SHOO_COOLDOWN_MS) {
+    // Re-arm only after the user lifts their finger clear of the sensor.
+    // Without this, a sustained low reading (finger held near the sensor
+    // through a fly's death + respawn) would re-trigger on the next fly.
+    if (dist > SHOO_RELEASE_CM) shooArmed = true;
+
+    if (shooArmed && dist < SHOO_TRIGGER_CM && now - lastShooTime > SHOO_COOLDOWN_MS) {
+      shooArmed = false;
       lastShooTime = now;
       appendSerialMonitorLine('>>> SHOO TRIGGERED');
       // #region agent log


### PR DESCRIPTION
## Summary

Two coupled fixes to the ultrasonic shoo trigger in `public/fly_swatter/index.html`.

### Double-hit bug

A single finger-flick was killing both the current fly *and* the next fly that spawned ~1 s later. Cause: the trigger gate had only a 600 ms cooldown — shorter than the fly-death → respawn cycle. If the user kept their finger near the sensor, the cooldown expired while the next fly was in flight, and the next packet triggered a second swat with zero new motion.

**Fix:** hysteresis. The sensor reading must rise back above 5 cm (`SHOO_RELEASE_CM`) before a new swat can register. One physical flick = one hit, structurally enforced regardless of cooldown timing. Cooldown also bumped 600 → 1200 ms as a backstop.

### Sensitivity −20%

`SHOO_TRIGGER_CM` lowered 2 → 1.6 cm. Finger has to come ~20% closer to register, reducing false fires from hovering / fidgeting.

## Test plan

- [ ] Connect controller, start the game
- [ ] Flick once, hold finger near sensor — first fly dies, next fly does NOT die (verifying release-gate)
- [ ] Lift hand clear (>5 cm), flick again — next fly dies ✓
- [ ] Hover at ~2 cm without flicking — no trigger ✓
- [ ] Two genuine quick flicks (each with retract) ~1 s apart — both register

## Out of scope

The clinician dashboard (`FlySwatterSettings`) already exposes `shooThresholdCm` and `shooCooldownMs` inputs, but the game never reads them. Wiring those up so clinicians can tune per-patient is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)