### PR TITLE
Restore Fossil Finder gyroscope-based input

### DIFF
--- a/app/patient/game/fossil-finder/page.tsx
+++ b/app/patient/game/fossil-finder/page.tsx
@@ -76,11 +76,13 @@ export default function FossilFinderPage() {
   const [phase, setPhase] = useState<CalibPhase>("idle");
   const [statusMsg, setStatusMsg] = useState("");
   const [usbConnected, setUsbConnected] = useState(false);
-  const [serialLogLines, setSerialLogLines] = useState<string[]>([]);
   const [serialMonitorOpen, setSerialMonitorOpen] = useState(true);
   /** Ref so pause works without stale closures on WebSerial callbacks. */
   const serialPausedRef = useRef(false);
   const [serialPaused, setSerialPaused] = useState(false);
+  const serialLinesRef = useRef<string[]>([]);
+  const serialPreRef = useRef<HTMLPreElement>(null);
+  const serialDirtyRef = useRef(false);
 
   // Refs — no re-render when mutated
   const phaseRef      = useRef<CalibPhase>("idle");
@@ -101,14 +103,20 @@ export default function FossilFinderPage() {
   const appendSerialLine = useCallback((line: string) => {
     if (serialPausedRef.current) return;
     const ts = new Date().toLocaleTimeString(undefined, { hour12: false });
-    setSerialLogLines((prev) => {
-      const next = [...prev, `[${ts}] ${line}`];
-      return next.length > SERIAL_LOG_MAX_LINES ? next.slice(-SERIAL_LOG_MAX_LINES) : next;
-    });
+    const buf = serialLinesRef.current;
+    buf.push(`[${ts}] ${line}`);
+    if (buf.length > SERIAL_LOG_MAX_LINES) {
+      serialLinesRef.current = buf.slice(-SERIAL_LOG_MAX_LINES);
+    }
+    serialDirtyRef.current = true;
   }, []);
 
   const clearSerialLog = useCallback(() => {
-    setSerialLogLines([]);
+    serialLinesRef.current = [];
+    serialDirtyRef.current = true;
+    if (serialPreRef.current) {
+      serialPreRef.current.textContent = "Waiting for lines from the controller…";
+    }
   }, []);
 
   const clearAllTimers = useCallback(() => {
@@ -150,11 +158,16 @@ export default function FossilFinderPage() {
         if (!line.startsWith("{")) return;
         try {
           const obj = JSON.parse(line) as Record<string, unknown>;
-          const d = obj.deviation;
-          if (typeof d === "number" && Number.isFinite(d)) {
-            appendSerialLine(`→ forwarded to game: deviation=${d.toFixed(2)}°`);
+          const gx = obj.gx;
+          const gy = obj.gy;
+          const gz = obj.gz;
+          if (
+            typeof gx === "number" && Number.isFinite(gx) &&
+            typeof gy === "number" && Number.isFinite(gy) &&
+            typeof gz === "number" && Number.isFinite(gz)
+          ) {
             iframeRef.current?.contentWindow?.postMessage(
-              { type: "fossil-sensor", deviation: d },
+              { type: "fossil-sensor", gx, gy, gz },
               window.location.origin
             );
           }
@@ -179,10 +192,11 @@ export default function FossilFinderPage() {
 
     try {
       const ok = await device.connect(115200);
-      if (!ok) throw new Error("Port selection cancelled");
+      if (!ok) return; // onError already set the error state + message
       deviceRef.current = device;
       setUsbConnected(true);
-      setSerialLogLines([]);
+      serialLinesRef.current = [];
+      serialDirtyRef.current = true;
       void device.startReading();
       await device.writeLine("mode:fossil-finder");
       setPhaseSync("calibrating");
@@ -255,6 +269,26 @@ export default function FossilFinderPage() {
       }
     };
   }, [clearAllTimers]);
+
+  // ── RAF loop for serial monitor (avoids re-renders on every packet) ─────────
+
+  useEffect(() => {
+    let raf: number;
+    const tick = () => {
+      if (serialDirtyRef.current && serialPreRef.current) {
+        serialDirtyRef.current = false;
+        const lines = serialLinesRef.current;
+        serialPreRef.current.textContent =
+          lines.length === 0
+            ? "Waiting for lines from the controller…"
+            : lines.join("\n");
+        serialPreRef.current.scrollTop = serialPreRef.current.scrollHeight;
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, []);
 
   const serialSupported =
     typeof navigator !== "undefined" && "serial" in navigator;
@@ -336,12 +370,11 @@ export default function FossilFinderPage() {
           </div>
           {serialMonitorOpen && (
             <pre
+              ref={serialPreRef}
               className="m-0 flex-1 overflow-auto whitespace-pre-wrap break-words p-2 font-mono text-[11px] leading-snug text-[#e8ddd4]"
               aria-label="USB serial debug output"
             >
-              {serialLogLines.length === 0
-                ? "Waiting for lines from the controller…"
-                : serialLogLines.join("\n")}
+              Waiting for lines from the controller…
             </pre>
           )}
         </div>

--- a/public/fossil_finder/fossil-finder-html/js/game.js
+++ b/public/fossil_finder/fossil-finder-html/js/game.js
@@ -46,8 +46,13 @@ class Game {
     this._onFossilSensor = (event) => {
       if (event.origin !== window.location.origin) return;
       const msg = event.data;
-      if (msg?.type === "fossil-sensor" && typeof msg.deviation === "number") {
-        this.toolController.feedDeviation(msg.deviation);
+      if (
+        msg?.type === "fossil-sensor" &&
+        typeof msg.gx === "number" &&
+        typeof msg.gy === "number" &&
+        typeof msg.gz === "number"
+      ) {
+        this.toolController.feedGyro(msg.gx, msg.gy, msg.gz);
       }
     };
     window.addEventListener("message", this._onFossilSensor);

--- a/public/fossil_finder/fossil-finder-html/js/tool-controller.js
+++ b/public/fossil_finder/fossil-finder-html/js/tool-controller.js
@@ -1,8 +1,8 @@
 import Bus from "./bus.js";
 
-// Dual-IMU `deviation` (deg): twist one way for left stroke, the other for right.
-const TILT_TRIGGER_DEG = 14;
-const TILT_NEUTRAL_DEG = 10;
+// Gyroscope spike detection: magnitude threshold + sign of gz for direction.
+const GYRO_TRIGGER_DEG_S = 150;  // deg/s magnitude to register a stroke
+const GYRO_COOLDOWN_MS = 250;    // minimum ms between strokes
 
 class ToolController {
   constructor(renderer, audioManager) {
@@ -13,6 +13,7 @@ class ToolController {
     this.canHit = true;
     this.hitDelay = 200;
     this.active = false;
+    this._lastGyroHitTime = 0;
 
     this.brushSounds = [
       "../assets/audio/sound_effects/brush/sfx_brush_stroke_normal-001.wav",
@@ -33,7 +34,7 @@ class ToolController {
       this.renderer.resetBrush();
     }
     this.canHit = true;
-    this._tiltArmed = true;
+    this._lastGyroHitTime = 0;
     this.active = true;
     window.removeEventListener("keydown", this._onKeyDown);
     window.addEventListener("keydown", this._onKeyDown);
@@ -64,38 +65,40 @@ class ToolController {
   }
 
   /**
-   * Latest `deviation` from parent-forwarded serial JSON (firmware IMU).
+   * Gyroscope rates from parent-forwarded serial JSON.
+   * Uses magnitude for spike detection and sign of gz for left/right direction.
    */
-  feedDeviation(deviation) {
+  feedGyro(gx, gy, gz) {
     if (!this.active || !this.canHit) return;
     if (this.strokeCount >= this.totalStrokes) return;
 
+    const now = performance.now();
+    if (now - this._lastGyroHitTime < GYRO_COOLDOWN_MS) return;
+
+    const magnitude = Math.sqrt(gx * gx + gy * gy + gz * gz);
+    if (magnitude < GYRO_TRIGGER_DEG_S) return;
+
+    // gz sign determines twist direction: positive → left stroke, negative → right stroke
+    const direction = gz >= 0 ? -1 : 1;
     const expected = this.getExpectedDirection();
 
-    if (this._tiltArmed) {
-      if (expected === -1 && deviation <= -TILT_TRIGGER_DEG) {
-        this._handleStroke(-1);
-        this._notifyParentStrokeRegistered(deviation, -1);
-      } else if (expected === 1 && deviation >= TILT_TRIGGER_DEG) {
-        this._handleStroke(1);
-        this._notifyParentStrokeRegistered(deviation, 1);
-      }
-    } else if (Math.abs(deviation) < TILT_NEUTRAL_DEG) {
-      this._tiltArmed = true;
+    if (direction === expected) {
+      this._lastGyroHitTime = now;
+      this._handleStroke(direction);
+      this._notifyParentStrokeRegistered(magnitude, gz, direction);
     }
   }
 
-  /** Embedded shell: log which deviation value registered as a brush stroke. */
-  _notifyParentStrokeRegistered(deviation, direction) {
+  _notifyParentStrokeRegistered(magnitude, gz, direction) {
     try {
       if (window.parent !== window) {
         window.parent.postMessage(
           {
             type: "fossil-stroke-registered",
-            deviation,
+            magnitude,
+            gz,
             direction,
-            triggerDeg: TILT_TRIGGER_DEG,
-            neutralDeg: TILT_NEUTRAL_DEG,
+            triggerDegS: GYRO_TRIGGER_DEG_S,
           },
           window.location.origin
         );


### PR DESCRIPTION
## Summary

Re-applies the gyroscope-based Fossil Finder input from PR #11 ([\`fef7919\`](https://github.com/parthiv-n/DXTR/commit/fef7919)) — undoing the Fossil-Finder portion of PR #12's batch revert ([\`73f6e17\`](https://github.com/parthiv-n/DXTR/commit/73f6e17)).

Car Racer was excluded from this restore (PR #18 already gave it a superior dual-path version). Fly Swatter and Rhythm Rehab stay on their post-revert implementations — not touched.

## What changes

- **`tool-controller.js`** — `feedDeviation()` removed, `feedGyro(gx, gy, gz)` restored. Stroke triggers when `√(gx² + gy² + gz²) ≥ 150 deg/s` with a 250 ms cooldown; direction from sign of `gz`; only fires when direction matches the expected next stroke.
- **`game.js`** — iframe message handler now expects `{type: "fossil-sensor", gx, gy, gz}` instead of `{type: "fossil-sensor", deviation}`.
- **`app/patient/game/fossil-finder/page.tsx`** — parent React wrapper reads `obj.gx/gy/gz` from each serial JSON line and forwards them via postMessage.

Diff is character-identical to the PR #11 hunks for these three files.

## Test plan

- [ ] After deploy, open Fossil Finder on `dxtr-psi.vercel.app`, connect controller
- [ ] Sharp wrist twist left → first stroke registers (LEFT)
- [ ] Sharp wrist twist right → second stroke registers (RIGHT)
- [ ] Alternating twists fill the 10-stroke set
- [ ] Slow / sub-150 deg/s motion does NOT trigger (this is intentional — known accessibility trade-off, was the reason for the original revert)

## Known limitation (carried over from PR #11)

150 deg/s threshold may be too sharp for stroke patients with limited wrist mobility. If that becomes a problem, follow Car Racer's PR #18 lead and add a dual-path version (slow tilt + fast twist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)