### PR TITLE
Hide serial monitors across all games

### DIFF
--- a/app/patient/game/fossil-finder/page.tsx
+++ b/app/patient/game/fossil-finder/page.tsx
@@ -77,7 +77,7 @@ export default function FossilFinderPage() {
   const [statusMsg, setStatusMsg] = useState("");
   const [usbConnected, setUsbConnected] = useState(false);
   const [serialLogLines, setSerialLogLines] = useState<string[]>([]);
-  const [serialMonitorOpen, setSerialMonitorOpen] = useState(true);
+  const [serialMonitorOpen, setSerialMonitorOpen] = useState(false);
   /** Ref so pause works without stale closures on WebSerial callbacks. */
   const serialPausedRef = useRef(false);
   const [serialPaused, setSerialPaused] = useState(false);

--- a/public/alien_abduction_game/index.html
+++ b/public/alien_abduction_game/index.html
@@ -154,7 +154,8 @@
       overflow: hidden;
       pointer-events: auto;
     }
-    #serial-monitor.visible { display: flex; }
+    #serial-monitor,
+    #serial-monitor.visible { display: none !important; }
     #serial-monitor .sm-head {
       flex-shrink: 0;
       display: flex;

--- a/public/rhythm-rehab/index.html
+++ b/public/rhythm-rehab/index.html
@@ -55,15 +55,7 @@
   .device-badge.connected { color:var(--green); border-color:rgba(74,222,128,0.3); }
   .device-badge.disconnected { color:var(--red); border-color:rgba(248,113,113,0.3); }
 
-  #serial-monitor {
-    position: fixed; top: 10px; left: 10px; z-index: 100;
-    background: rgba(0,0,0,0.85); border: 1px solid #7BC47F;
-    padding: 10px 14px; border-radius: 10px;
-    font-size: 0.78em; color: #e0e0e0;
-    font-family: "Courier New", monospace;
-    min-width: 190px; box-shadow: 0 4px 12px rgba(0,0,0,0.5);
-    backdrop-filter: blur(4px);
-  }
+  #serial-monitor { display: none !important; }
   #serial-monitor .mon-section { padding: 6px 0; border-top: 1px solid rgba(255,255,255,0.18); }
   #serial-monitor .mon-section:first-of-type { border-top: none; padding-top: 0; }
   #serial-monitor .mon-val { font-weight: bold; color: #5BB5CF; }

--- a/public/witch_runner/index.html
+++ b/public/witch_runner/index.html
@@ -59,7 +59,8 @@
         overflow: hidden;
         pointer-events: auto;
       }
-      #serial-monitor.visible { display: flex; }
+      #serial-monitor,
+      #serial-monitor.visible { display: none !important; }
       #serial-monitor .sm-head {
         flex-shrink: 0;
         display: flex;


### PR DESCRIPTION
## Summary
- Override the \`#serial-monitor.visible\` rule with \`display: none !important\` in **witch_runner** and **alien_abduction_game** so the in-game monitor stays hidden even when its toggle is enabled (user reported the witch-runner monitor was still showing).
- Hide the always-visible monitor panel I added to **rhythm-rehab** earlier in this branch.
- Default the **fossil-finder** parent serial monitor drawer to closed on first render.
- \`car-game\` already had this CSS override from main; \`fly-swatter\` has no monitor.

## Test plan
- [ ] Witch Runner: connect controller, confirm no serial-monitor box appears bottom-left
- [ ] Alien Abduction: same
- [ ] Rhythm Rehab: no monitor box in the top-left corner during gameplay
- [ ] Fossil Finder: serial monitor drawer is collapsed on first open of the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)