### PR TITLE
alien-abduction: fix connect race and missing FSR mode-switch

### DIFF
--- a/public/alien_abduction_game/index.html
+++ b/public/alien_abduction_game/index.html
@@ -385,6 +385,7 @@
   }
 
   function cleanupSerialOnUnload() {
+    if (fsrWatchdogTimer) { clearTimeout(fsrWatchdogTimer); fsrWatchdogTimer = null; }
     try { if (esp32Connected) sendModeCommand('idle'); } catch (_) {}
     // Fire-and-forget: must release the SerialPort before the iframe is destroyed,
     // otherwise the next game's requestPort() returns an already-open port.
@@ -454,11 +455,19 @@
   }
 
   // Absorb the race between a previous iframe's close() and this iframe's open().
+  // If the port is still readable (open from a prior page that didn't fully release),
+  // close it first — otherwise port.open() throws "Failed to open serial port".
   async function openWithRetry(port, options, tries, delayMs) {
     tries = tries || 5; delayMs = delayMs || 200;
     var lastErr;
     for (var i = 0; i < tries; i++) {
-      try { await port.open(options); return; }
+      try {
+        if (port.readable !== null) {
+          try { await port.close(); } catch (_) {}
+        }
+        await port.open(options);
+        return;
+      }
       catch (e) { lastErr = e; await new Promise(function(r){ setTimeout(r, delayMs); }); }
     }
     throw lastErr;
@@ -484,7 +493,11 @@
       esp32Connected = true;
       updateDeviceStatus('connected');
       readESP32Data();
-      sendModeCommand('alien-abduction');
+      // Send mode command, then arm a watchdog: if no fsrbutton_voltage JSON
+      // arrives within 1.5 s, the firmware probably missed the switch
+      // (race when transitioning from a previous game's mode). Resend.
+      await sendModeCommand('alien-abduction');
+      armFsrWatchdog();
       return true;
     } catch (error) {
       console.error('ESP32 serial connection error:', error);
@@ -557,7 +570,8 @@
       connectionType = 'ble';
       esp32Connected = true;
       updateDeviceStatus('connected');
-      sendModeCommand('alien-abduction');
+      await sendModeCommand('alien-abduction');
+      armFsrWatchdog();
       return true;
     } catch (e) {
       bleDevice = null;
@@ -593,7 +607,8 @@
       connectionType = 'ble';
       esp32Connected = true;
       updateDeviceStatus('connected');
-      sendModeCommand('alien-abduction');
+      await sendModeCommand('alien-abduction');
+      armFsrWatchdog();
       return true;
     } catch (error) {
       console.error('BLE connection error:', error);
@@ -638,6 +653,7 @@
   async function disconnectESP32() {
     try {
       esp32Connected = false;
+      if (fsrWatchdogTimer) { clearTimeout(fsrWatchdogTimer); fsrWatchdogTimer = null; }
       if (connectionType === 'serial') {
         if (esp32Reader) { await esp32Reader.cancel(); esp32Reader = null; }
         if (esp32Port)   { await esp32Port.close();    esp32Port   = null; }
@@ -659,6 +675,29 @@
     }
   }
 
+  // ── FSR mode-command watchdog ───────────────────────────────────────────────
+  // If we connected but the firmware is still streaming a previous game's JSON
+  // shape (no fsrbutton_voltage), resend mode:alien-abduction. Cleared once we
+  // see real FSR data.
+  var sawFsrData = false;
+  var fsrWatchdogTimer = null;
+  function armFsrWatchdog() {
+    sawFsrData = false;
+    if (fsrWatchdogTimer) { clearTimeout(fsrWatchdogTimer); fsrWatchdogTimer = null; }
+    var attempts = 0;
+    var tick = function() {
+      if (!esp32Connected || sawFsrData) { fsrWatchdogTimer = null; return; }
+      attempts++;
+      try { sendModeCommand('alien-abduction'); } catch (_) {}
+      if (attempts < 4) {
+        fsrWatchdogTimer = setTimeout(tick, 1500);
+      } else {
+        fsrWatchdogTimer = null;
+      }
+    };
+    fsrWatchdogTimer = setTimeout(tick, 1500);
+  }
+
   // ── FSR button voltage → spacePressed mapping ───────────────────────────────
   // Reads fsrbutton_voltage and fsrbutton2_voltage directly; fires if either >= threshold
 
@@ -666,6 +705,7 @@
     try {
       var data = JSON.parse(jsonString);
       if (typeof data.fsrbutton_voltage === 'number' || typeof data.fsrbutton2_voltage === 'number') {
+        sawFsrData = true;
         var v1 = typeof data.fsrbutton_voltage  === 'number' ? data.fsrbutton_voltage  : 0;
         var v2 = typeof data.fsrbutton2_voltage === 'number' ? data.fsrbutton2_voltage : 0;
         var buttonVoltage = v1 > v2 ? v1 : v2;


### PR DESCRIPTION
## Summary
Fixes the two regressions causing alien-abduction to fail when navigating in from another game:

1. **Connect race in \`openWithRetry()\`** — \`port.open()\` was called without first closing a still-readable port. If the previous iframe's \`pagehide\` cleanup hadn't fully released the port, every retry hit \"Failed to open serial port\". Now calls \`port.close()\` before each retry attempt when \`port.readable\` is non-null (same pattern as \`lib/device/webSerial.ts\`).

2. **Mode-switch race** — \`sendModeCommand('alien-abduction')\` was fire-and-forget after connect. If the firmware was mid-transition out of the previous game's mode (e.g. rhythm-rehab gyro mode), the command could miss and the firmware kept streaming gyro JSON. The game's parser ignores anything without \`fsrbutton_voltage\`, so FSR presses produced no input.

   Now awaits \`sendModeCommand\` and arms a 1.5s FSR watchdog: if no \`fsrbutton_voltage\` JSON arrives, resends \`mode:alien-abduction\` (up to 4 retries). Cleared on first real FSR data, on disconnect, and on \`pagehide\`.

Applied to both USB serial and BLE connect paths.

## Test plan
- [ ] Open rhythm-rehab → back → alien-abduction. Auto-reconnect succeeds; pressing FSR triggers the abduction beam within ~1.5s of the iframe loading
- [ ] Open alien-abduction fresh: USB Serial → Connect → press FSR → beam fires
- [ ] BLE path: same behaviour
- [ ] Rapid game cycling (rhythm-rehab → alien-abduction → rhythm-rehab → alien-abduction): no \"Failed to open serial port\", FSR keeps working
- [ ] Check console: no errors during the watchdog retries

🤖 Generated with [Claude Code](https://claude.com/claude-code)